### PR TITLE
Validate generated schemas as part of tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/*
 dist/*
 genson.egg-info/*
+*.egg

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -7,4 +7,4 @@ Credits
 Contributors
 ------------
 
-No one as yet. You could change that...
+- `Brad Sokol <https://github.com/bradsokol>`_

--- a/bin/test.py
+++ b/bin/test.py
@@ -1,17 +1,16 @@
 #!/usr/bin/env python
 
-import unittest
-import sys
 import os
+import subprocess
+import sys
 
 
 def main():
-    loader = unittest.TestLoader()
-    tests = loader.discover(os.path.join(sys.path[0], '../test'))
-
-    runner = unittest.TextTestRunner()
-    runner.run(tests)
+    return subprocess.call(
+        ['python', 'setup.py', 'test'] + sys.argv[1:],
+        cwd=os.path.join(os.path.dirname(__file__), os.pardir)
+    )
 
 
 if __name__ == '__main__':
-    main()
+    sys.exit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@ universal = 1
 
 [metadata]
 description-file = README.md
+
+[global]
+verbose = False

--- a/setup.py
+++ b/setup.py
@@ -43,4 +43,8 @@ setup(
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Utilities',
     ],
+    tests_require=[
+        'jsonschema>=2.5.1',
+    ],
+    test_suite='test',
 )

--- a/test/base.py
+++ b/test/base.py
@@ -1,0 +1,17 @@
+import sys
+import unittest
+
+try:
+    import jsonschema
+except ImportError:
+    print('Failed to import jsonschema module. Schemas will not be validated.')
+
+
+class SchemaTestCase(unittest.TestCase):
+    def assertSchema(self, actual, expected):
+        self.assertValidSchema(actual)
+        self.assertEqual(actual, expected)
+
+    def assertValidSchema(self, schema):
+        if 'jsonschema' in sys.modules:
+            jsonschema.Draft4Validator.check_schema(schema)

--- a/test/base.py
+++ b/test/base.py
@@ -1,10 +1,6 @@
-import sys
 import unittest
 
-try:
-    import jsonschema
-except ImportError:
-    print('Failed to import jsonschema module. Schemas will not be validated.')
+import jsonschema
 
 
 class SchemaTestCase(unittest.TestCase):
@@ -13,5 +9,4 @@ class SchemaTestCase(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     def assertValidSchema(self, schema):
-        if 'jsonschema' in sys.modules:
-            jsonschema.Draft4Validator.check_schema(schema)
+        jsonschema.Draft4Validator.check_schema(schema)

--- a/test/test_add_single.py
+++ b/test/test_add_single.py
@@ -4,42 +4,43 @@ import sys
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 from genson import Schema
+import base
 
 
-class TestType(unittest.TestCase):
+class TestType(base.SchemaTestCase):
 
     def test_no_schema(self):
         schema = {}
         s = Schema()
         s.add_schema(schema)
-        self.assertEqual(s.to_dict(), schema)
+        self.assertSchema(s.to_dict(), schema)
 
     def test_single_type(self):
         schema = {'type': 'string'}
         s = Schema()
         s.add_schema(schema)
-        self.assertEqual(s.to_dict(), schema)
+        self.assertSchema(s.to_dict(), schema)
 
     def test_single_type_unicode(self):
         schema = {u'type': u'string'}
         s = Schema()
         s.add_schema(schema)
-        self.assertEqual(s.to_dict(), schema)
+        self.assertSchema(s.to_dict(), schema)
 
     def test_multi_type(self):
         schema = {'type': ['boolean', 'null', 'number', 'string']}
         s = Schema()
         s.add_schema(schema)
-        self.assertEqual(s.to_dict(), schema)
+        self.assertSchema(s.to_dict(), schema)
 
 
-class TestPreserveKeys(unittest.TestCase):
+class TestPreserveKeys(base.SchemaTestCase):
 
     def test_preserves_existing_keys(self):
         schema = {'type': 'number', 'value': 5}
         s = Schema()
         s.add_schema(schema)
-        self.assertEqual(s.to_dict(), schema)
+        self.assertSchema(s.to_dict(), schema)
 
 
 if __name__ == '__main__':

--- a/test/test_gen_multi.py
+++ b/test/test_gen_multi.py
@@ -4,16 +4,17 @@ import sys
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 from genson import Schema
+import base
 
 
-class TestBasicTypes(unittest.TestCase):
+class TestBasicTypes(base.SchemaTestCase):
 
     def test_single_type(self):
         s = Schema()
         s.add_object('bacon')
         s.add_object('egg')
         s.add_object('spam')
-        self.assertEqual(s.to_dict(), {'type': 'string'})
+        self.assertSchema(s.to_dict(), {'type': 'string'})
 
     def test_multi_type(self):
         s = Schema()
@@ -21,15 +22,15 @@ class TestBasicTypes(unittest.TestCase):
         s.add_object(1.1)
         s.add_object(True)
         s.add_object(None)
-        self.assertEqual(s.to_dict(),
-                         {'type': ['boolean', 'null', 'number', 'string']})
+        self.assertSchema(s.to_dict(),
+                          {'type': ['boolean', 'null', 'number', 'string']})
 
     def test_redundant_integer_type(self):
         s = Schema()
         s.add_object(1)
         s.add_object(1.1)
-        self.assertEqual(s.to_dict(),
-                         {'type': 'number'})
+        self.assertSchema(s.to_dict(),
+                          {'type': 'number'})
 
 
 if __name__ == '__main__':

--- a/test/test_gen_single.py
+++ b/test/test_gen_single.py
@@ -4,50 +4,51 @@ import sys
 sys.path.insert(1, os.path.join(sys.path[0], '..'))
 
 from genson import Schema
+import base
 
 
-class TestBasicTypes(unittest.TestCase):
+class TestBasicTypes(base.SchemaTestCase):
 
     def test_no_object(self):
         s = Schema()
-        self.assertEqual(s.to_dict(), {})
+        self.assertSchema(s.to_dict(), {})
 
     def test_string(self):
         s = Schema().add_object("string")
-        self.assertEqual(s.to_dict(), {"type": "string"})
+        self.assertSchema(s.to_dict(), {"type": "string"})
 
     def test_integer(self):
         s = Schema().add_object(1)
-        self.assertEqual(s.to_dict(), {"type": "integer"})
+        self.assertSchema(s.to_dict(), {"type": "integer"})
 
     def test_number(self):
         s = Schema().add_object(1.1)
-        self.assertEqual(s.to_dict(), {"type": "number"})
+        self.assertSchema(s.to_dict(), {"type": "number"})
 
     def test_boolean(self):
         s = Schema().add_object(True)
-        self.assertEqual(s.to_dict(), {"type": "boolean"})
+        self.assertSchema(s.to_dict(), {"type": "boolean"})
 
     def test_null(self):
         s = Schema().add_object(None)
-        self.assertEqual(s.to_dict(), {"type": "null"})
+        self.assertSchema(s.to_dict(), {"type": "null"})
 
 
-class TestArray(unittest.TestCase):
+class TestArray(base.SchemaTestCase):
 
     def test_empty(self):
         s = Schema().add_object([])
-        self.assertEqual(s.to_dict(),
-                         {"type": "array", "items": []})
+        self.assertSchema(s.to_dict(),
+                          {"type": "array", "items": []})
 
     def test_monotype(self):
         s = Schema().add_object(["spam", "spam", "spam", "egg", "spam"])
-        self.assertEqual(s.to_dict(),
-                         {"type": "array", "items": [{"type": "string"}]})
+        self.assertSchema(s.to_dict(),
+                          {"type": "array", "items": [{"type": "string"}]})
 
     def test_multitype_merge(self):
         s = Schema().add_object([1, "2", None, False])
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "type": "array",
             "items": [{
                 "type": ["boolean", "integer", "null", "string"]}]
@@ -55,7 +56,7 @@ class TestArray(unittest.TestCase):
 
     def test_multitype_sep(self):
         s = Schema(merge_arrays=False).add_object([1, "2", None, False])
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "type": "array",
             "items": [
                 {"type": "integer"},
@@ -65,18 +66,18 @@ class TestArray(unittest.TestCase):
             })
 
 
-class TestObject(unittest.TestCase):
+class TestObject(base.SchemaTestCase):
 
     def test_empty_object(self):
         s = Schema().add_object({})
-        self.assertEqual(s.to_dict(), {"type": "object", "properties": {}})
+        self.assertSchema(s.to_dict(), {"type": "object", "properties": {}})
 
     def test_basic_object(self):
         s = Schema().add_object({
             "Red Windsor": "Normally, but today the van broke down.",
             "Stilton": "Sorry.",
             "Gruyere": False})
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "required": ["Gruyere", "Red Windsor", "Stilton"],
             "type": "object",
             "properties": {
@@ -86,7 +87,7 @@ class TestObject(unittest.TestCase):
             })
 
 
-class TestComplex(unittest.TestCase):
+class TestComplex(base.SchemaTestCase):
 
     def test_array_reduce(self):
         s = Schema().add_object([["surprise"],
@@ -94,7 +95,7 @@ class TestComplex(unittest.TestCase):
                                  ["fear", "surprise", "ruthless efficiency"],
                                  ["fear", "surprise", "ruthless efficiency",
                                   "an almost fanatical devotion to the Pope"]])
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "type": "array",
             "items": [{
                 "type": "array",
@@ -103,7 +104,7 @@ class TestComplex(unittest.TestCase):
 
     def test_array_in_object(self):
         s = Schema().add_object({"a": "b", "c": [1, 2, 3]})
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "required": [
                 "a",
                 "c"
@@ -132,7 +133,7 @@ class TestComplex(unittest.TestCase):
             {"name": "Sir Robin of Camelot",
              "quest": "to seek the Holy Grail",
              "capitol of Assyria": None}])
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "items": [
                 {
                     "required": [
@@ -162,7 +163,7 @@ class TestComplex(unittest.TestCase):
     def test_three_deep(self):
         s = Schema().add_object(
             {"matryoshka": {"design": {"principle": "FTW!"}}})
-        self.assertEqual(s.to_dict(), {
+        self.assertSchema(s.to_dict(), {
             "required": ["matryoshka"],
             "type": "object",
             "properties": {"matryoshka": {


### PR DESCRIPTION
Uses jsonschema to validate schemas as part of tests. If the jsonschema
package is not installed, tests still test for equality but schema
validation is skipped. A warning message is displayed.

Since there was no requirements file, I wanted to keep that pattern. If you are ok with adding  requirements, I can amend the PR and remove the import trick.