### PR TITLE
Emit valid schema when arrays in sample objects are empty.

### DIFF
--- a/genson/generator.py
+++ b/genson/generator.py
@@ -107,7 +107,9 @@ class Schema(object):
                 schema['required'] = self._get_required()
 
         elif 'array' in self._type:
-            schema['items'] = self._get_items(recurse)
+            items = self._get_items(recurse)
+            if items:
+                schema['items'] = items
 
         return schema
 

--- a/test/test_gen_single.py
+++ b/test/test_gen_single.py
@@ -38,7 +38,7 @@ class TestArray(unittest.TestCase):
     def test_empty(self):
         s = Schema().add_object([])
         self.assertEqual(s.to_dict(),
-                         {"type": "array", "items": []})
+                         {"type": "array"})
 
     def test_monotype(self):
         s = Schema().add_object(["spam", "spam", "spam", "egg", "spam"])


### PR DESCRIPTION
Fixes a bug where an empty `items` array is specified in the schema
when the "training" objects all contain empty arrays. In other words,
the schema contains `{"type": "array", "items": []}`. The empty array
in the `items` entry is not valid.

The fix was to not emit the `items` entry if the array is empty.

See PR #4 that adds schema validation to the tests to catch this kind of issue.