### PR TITLE
Adding support for long numbers

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,3 +9,4 @@ Contributors
 
 - `Brad Sokol <https://github.com/bradsokol>`_
 - `David Kay <https://github.com/davek2>`_
+- `Heiho1 <https://github.com/heiho1>`_

--- a/genson/schema/generators/scalar.py
+++ b/genson/schema/generators/scalar.py
@@ -47,8 +47,8 @@ class Number(SchemaGenerator):
     converts from `integer` to `number` when a float object or a
     number schema is added
     """
-    JS_TYPES = ('integer', 'number')
-    PYTHON_TYPES = (int, float)
+    JS_TYPES = ('integer', 'number', 'number')
+    PYTHON_TYPES = (int, float, long)
 
     @classmethod
     def match_schema(cls, schema):

--- a/genson/schema/generators/scalar.py
+++ b/genson/schema/generators/scalar.py
@@ -47,8 +47,14 @@ class Number(SchemaGenerator):
     converts from `integer` to `number` when a float object or a
     number schema is added
     """
-    JS_TYPES = ('integer', 'number', 'number')
-    PYTHON_TYPES = (int, float, long)
+    import sys
+    JS_TYPES = ('integer', 'number', 'integer')
+    if (sys.version_info < (3,)):
+        JS_TYPES = ('integer', 'number', 'integer')
+        PYTHON_TYPES = (int, float, long)
+    else:
+        JS_TYPES = ('integer', 'number')
+        PYTHON_TYPES = (int, float)
 
     @classmethod
     def match_schema(cls, schema):

--- a/test/test_gen_single.py
+++ b/test/test_gen_single.py
@@ -27,6 +27,14 @@ class TestBasicTypes(base.SchemaNodeTestCase):
         self.assertResult({"type": "null"})
 
 
+class TestPython27Long(TestBasicTypes):
+    def test_long(self):
+        import sys
+        if (sys.version_info < (3,)):
+            self.add_object(1l)
+            self.assertResult({"type": "integer"})
+
+
 class TestArrayList(base.SchemaNodeTestCase):
 
     def setUp(self):


### PR DESCRIPTION
Had a JSON doc with 1234L in it [unix timestamp value] and noticed that long type was not mapped in the scalar generator.