### PR TITLE
Add `Enum` schema strategy

### DIFF
--- a/genson/schema/strategies/__init__.py
+++ b/genson/schema/strategies/__init__.py
@@ -11,6 +11,7 @@ from .scalar import (
 )
 from .array import List, Tuple
 from .object import Object
+from .enum import Enum
 
 BASIC_SCHEMA_STRATEGIES = (
     Null,
@@ -33,5 +34,6 @@ __all__ = (
     'Tuple',
     'Object',
     'Typeless',
+    'Enum',
     'BASIC_SCHEMA_STRATEGIES'
 )

--- a/genson/schema/strategies/enum.py
+++ b/genson/schema/strategies/enum.py
@@ -1,0 +1,35 @@
+from .base import SchemaStrategy
+
+
+class Enum(SchemaStrategy):
+    """
+    strategy for 'enum' schemas. Merges the 'enum' types into one set and then
+    returns a schema with 'enum' set to the corresponding list.
+    """
+    KEYWORDS = ('enum', )
+
+    def __init__(self, node_class):
+        super().__init__(node_class)
+        # Use set to easily merge 'enum's from different schemas.
+        self._enum = set()
+
+    @staticmethod
+    def match_schema(schema):
+        return 'enum' in schema
+
+    @classmethod
+    def match_object(cls, obj):
+        return False
+
+    def add_schema(self, schema):
+        super().add_schema(schema)
+        if self._enum == set():
+            self._enum = set(schema.get('enum'))
+        elif 'enum' in schema:
+            self._enum.update(schema['enum'])
+
+    def to_schema(self):
+        schema = super().to_schema()
+        # Revert set back to list
+        schema['enum'] = list(self._enum)
+        return schema


### PR DESCRIPTION
Fixes #46 

Add a new subclass of `SchemaStrategy` for supporting the 'enum`
keyword.

The `Enum` class keeps track of a `set` that contains all of the values
that were provided by the 'enum' keywords in the schemas. When the
builder is converted to a schema, this set is converted to a list.