### PR TITLE
Adding the ability to set a 'required' boolean kwarg in the Object.add_object method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -12,3 +12,4 @@ Contributors
 - `Heiho1 <https://github.com/heiho1>`_
 - `YehudaCorsia <https://github.com/YehudaCorsia>`_
 - `KOLANICH <https://github.com/KOLANICH>`_
+- `Shane Curtin <https://github.com/sj-curtin>`_

--- a/README.rst
+++ b/README.rst
@@ -153,12 +153,13 @@ Merge in a JSON schema. This can be a ``dict`` or another ``SchemaBuilder`` obje
     There is no schema validation. If you pass in a bad schema,
     you might get back a bad schema.
 
-``add_object(obj)``
-^^^^^^^^^^^^^^^^^^^
+``add_object(obj, **kwargs)``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Modify the schema to accommodate an object.
 
 :param obj: any object or scalar that can be serialized in JSON
+:param \**required (bool): if set to `False` the required keyword in the schema will not be included
 
 ``to_schema()``
 ^^^^^^^^^^^^^^^

--- a/genson/schema/builder.py
+++ b/genson/schema/builder.py
@@ -83,13 +83,13 @@ class SchemaBuilder(metaclass=_MetaSchemaBuilder):
             del schema['$schema']
         self._root_node.add_schema(schema)
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         """
         Modify the schema to accommodate an object.
 
         :param obj: any object or scalar that can be serialized in JSON
         """
-        self._root_node.add_object(obj)
+        self._root_node.add_object(obj, **kwargs)
 
     def to_schema(self):
         """

--- a/genson/schema/node.py
+++ b/genson/schema/node.py
@@ -36,7 +36,7 @@ class SchemaNode:
         # return self for easy method chaining
         return self
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         """
         Modify the schema to accommodate an object.
 
@@ -47,7 +47,7 @@ class SchemaNode:
 
         # delegate to SchemaType object
         active_strategy = self._get_strategy_for_object(obj)
-        active_strategy.add_object(obj)
+        active_strategy.add_object(obj, **kwargs)
 
         # return self for easy method chaining
         return self

--- a/genson/schema/strategies/array.py
+++ b/genson/schema/strategies/array.py
@@ -38,9 +38,9 @@ class List(BaseArray):
         if 'items' in schema:
             self._items.add_schema(schema['items'])
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         for item in obj:
-            self._items.add_object(item)
+            self._items.add_object(item, **kwargs)
 
     def items_to_schema(self):
         return self._items.to_schema()

--- a/genson/schema/strategies/base.py
+++ b/genson/schema/strategies/base.py
@@ -43,7 +43,7 @@ class SchemaStrategy:
                       'values ({1!r} vs. {2!r}). Using {1!r}').format(
                           keyword, self._extra_keywords[keyword], value))
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         pass
 
     def to_schema(self):

--- a/genson/schema/strategies/object.py
+++ b/genson/schema/strategies/object.py
@@ -46,7 +46,7 @@ class Object(SchemaStrategy):
             else:
                 self._required &= required
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         properties = set()
         for prop, subobj in obj.items():
             pattern = None
@@ -55,12 +55,15 @@ class Object(SchemaStrategy):
                 pattern = self._matching_pattern(prop)
 
             if pattern is not None:
-                self._pattern_properties[pattern].add_object(subobj)
+                self._pattern_properties[pattern].add_object(subobj, **kwargs)
             else:
                 properties.add(prop)
-                self._properties[prop].add_object(subobj)
+                self._properties[prop].add_object(subobj, **kwargs)
 
-        if self._required is None:
+        # If 'required' is set to False they will not be added to the schema
+        if kwargs.get("required") is False:
+            self._required = set()
+        elif self._required is None:
             self._required = properties
         else:
             self._required &= properties

--- a/genson/schema/strategies/scalar.py
+++ b/genson/schema/strategies/scalar.py
@@ -68,7 +68,7 @@ class Number(SchemaStrategy):
         if schema.get('type') == 'number':
             self._type = 'number'
 
-    def add_object(self, obj):
+    def add_object(self, obj, **kwargs):
         if isinstance(obj, float):
             self._type = 'number'
 

--- a/test/base.py
+++ b/test/base.py
@@ -16,8 +16,8 @@ class BaseTestCase(unittest.TestCase):
     def set_schema_options(self, **options):
         self.builder = SchemaNode(**options)
 
-    def add_object(self, obj):
-        self.builder.add_object(obj)
+    def add_object(self, obj, **kwargs):
+        self.builder.add_object(obj, **kwargs)
         self._objects.append(obj)
 
     def add_schema(self, schema):

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -28,6 +28,39 @@ class TestMethods(base.SchemaBuilderTestCase):
             "$schema": SchemaBuilder.DEFAULT_URI,
             "type": "null"})
 
+    def test_add_object_required_false(self):
+        mock_dict = {
+            "mock_value_one": "abc"
+        }
+        self.add_object(mock_dict, required=False)
+
+        self.assertResult({
+            "$schema": SchemaBuilder.DEFAULT_URI,
+            "type": "object",
+            "properties": {
+                "mock_value_one": {
+                    "type": "string"
+                }
+            }
+        })
+
+    def test_add_object_required_true(self):
+        mock_dict = {
+            "mock_value_one": "abc"
+        }
+        self.add_object(mock_dict, required=True)
+
+        self.assertResult({
+            "$schema": SchemaBuilder.DEFAULT_URI,
+            "type": "object",
+            "properties": {
+                "mock_value_one": {
+                    "type": "string"
+                }
+            },
+            "required": ["mock_value_one"]
+        })
+
     def test_to_json(self):
         self.assertEqual(
             self.builder.to_json(),


### PR DESCRIPTION
- Doing so will avoid the `required` keyword for an object in
the schema to be included
- Added test cases
- Updated docs

Added GenSON to a recent project and found it very useful - thank you 🙌 

## Use case:
"If JSON is validated against a schema produced and it is missing an object key, it should still be deemed valid"

Our solution was a little overwrite of the add_object method for Objects - however we also toyed with this approach - what are your thoughts?

## Our change:
```
mock_dict = {"mock_value_one": "abc"}
builder = SchemaBuilder()
builder.add_object(mock_dict, required=False)
print(builder.to_json())

>>> {"$schema": "http://json-schema.org/schema#", "type": "object", "properties": {"mock_value_one": {"type": "string"}}}
```

## Default:
```
mock_dict = {"mock_value_one": "abc"}
builder = SchemaBuilder()
builder.add_object(mock_dict)
print(builder.to_json())

>>> {"$schema": "http://json-schema.org/schema#", "type": "object", "properties": {"mock_value_one": {"type": "string"}}, "required": ["mock_value_one"]}
```
