### PR TITLE
Ignore whitespace differences when testing error messages

### DIFF
--- a/test/test_bin.py
+++ b/test/test_bin.py
@@ -75,20 +75,32 @@ class TestError(unittest.TestCase):
         'invalid JSON in %s: Expecting value: line 1 column 1 (char 0)'
         % BAD_JSON_FILE)
 
+    def assertEqualIgnoreWhitespace(
+            self,
+            first: str,
+            second: str,
+            msg: "str|None" = None,
+        ):
+        return self.assertEqual(
+            " ".join(first.split()),
+            " ".join(second.split()),
+            msg=msg
+        )
+
     def test_no_input(self):
         (stdout, stderr) = run()
-        self.assertEqual(stderr, stderr_message(
+        self.assertEqualIgnoreWhitespace(stderr, stderr_message(
             'noting to do - no schemas or objects given'))
         self.assertEqual(stdout, '')
 
     def test_object_not_json(self):
         (stdout, stderr) = run([self.BAD_JSON_FILE])
-        self.assertEqual(stderr, self.BAD_JSON_MESSAGE)
+        self.assertEqualIgnoreWhitespace(stderr, self.BAD_JSON_MESSAGE)
         self.assertEqual(stdout, '')
 
     def test_schema_not_json(self):
         (stdout, stderr) = run(['-s', self.BAD_JSON_FILE])
-        self.assertEqual(stderr, self.BAD_JSON_MESSAGE)
+        self.assertEqualIgnoreWhitespace(stderr, self.BAD_JSON_MESSAGE)
         self.assertEqual(stdout, '')
 
 


### PR DESCRIPTION
## Problem

When I run the unit tests locally, I get failures for `test_bin.py`'s `TestError` tests. It looks to be because my detected terminal width is configured differently than is expected, so the "usage" portion of the error message wraps differently than expected:

```python
py37: commands[0]> coverage run --source=genson -m unittest
.......................................FFF.............................................................
======================================================================
FAIL: test_no_input (test.test_bin.TestError)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "D:\repos\GenSON\test\test_bin.py", line 81, in test_no_input
    'noting to do - no schemas or objects given'))
AssertionError: 'usag[59 chars]CES]\r\n              [-s SCHEMA] [-$ SCHEMA_U[85 chars]\r\n' != 'usag[59 chars]CES]\n              [-s SCHEMA] [-$ SCHEMA_URI[77 chars]en\n'
- usage: genson [-h] [--version] [-d DELIM] [-e ENCODING] [-i SPACES]
?                                                                    -
+ usage: genson [-h] [--version] [-d DELIM] [-e ENCODING] [-i SPACES]
-               [-s SCHEMA] [-$ SCHEMA_URI]
?                                          -
+               [-s SCHEMA] [-$ SCHEMA_URI]
-               ...
?                  -
+               ...
- genson: error: noting to do - no schemas or objects given
?                                                          -
+ genson: error: noting to do - no schemas or objects given
```

## Proposed solution

Add a method `TestError.assertEqualIgnoreWhitespace()` that replaces any chunk of whitespace with a single space before comparing two strings, and call this method when comparing `stderr` to the expected output.

## Also considered

I looked through the [Python `unittest` documentation](https://docs.python.org/3/library/unittest.html), and I was unable to find an existing method that would ignore differences in whitespace when asserting equality between two strings.

I considered using a regular expression to standardize whitespace differences (one of the proposed solutions on [this StackOverflow question](https://stackoverflow.com/questions/2077897/substitute-multiple-whitespace-with-single-whitespace-in-python)), but that would add an import and (in my opinion) some unnecessary complexity.