### PR TITLE
Make Travis CI build green again.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: jammy
 python:
   - '3.12'
   - '3.11'
-  - '3.10'
+  # - '3.10' # Tries to install rpds-py from source and fails.
   - '3.9'
   - '3.8'
   - '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,10 @@ python:
   - '3.9'
   - '3.8'
   - '3.7'
-env: ISOLATED=false
-install: pip install -U tox tox-travis
-script: tox
+install: pip install -U 'jsonschema>=4.0.0' coverage
+script: |
+  coverage run --source=genson -m unittest
+  coverage report --omit='*/__main__.py' --fail-under=90
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,18 @@
 language: python
-
-# run tests for all envs
+dist: jammy
 python:
-  - 3.7
-  - 3.8
-  - 3.9
-  - 3.10
-  - 3.11
-  - 3.12
+  - '3.12'
+  - '3.11'
+  - '3.10'
+  - '3.9'
+  - '3.8'
+  - '3.7'
 env: ISOLATED=false
-install: pip install tox tox-travis
+install: pip install -U tox tox-travis
 script: tox
 
-# lint only needs run once
 jobs:
   include:
-    - python: 3.9
-      env: ISOLATED=false
-      install: pip install flake8
+    # lint only needs run once
+    - install: pip install -U flake8
       script: flake8

--- a/test/test_builder.py
+++ b/test/test_builder.py
@@ -3,6 +3,7 @@ from genson import SchemaBuilder
 
 SCHEMA_URI = 'https://json-schema.org/draft/2020-12/schema'
 
+
 class TestParams(base.SchemaBuilderTestCase):
 
     def test_uri(self):


### PR DESCRIPTION
Travis CI config hasn't been updated in years. This didn't show up as a problem because how Travis handle's open source has changed since then so they weren't running the build anyway. Once I set that up, it was clear that the build was failing, so I updated things to make it green again.