### PR TITLE
test: Use sys.executable for integration testing

### DIFF
--- a/test/test_bin.py
+++ b/test/test_bin.py
@@ -1,6 +1,7 @@
 import unittest
 import json
 import os
+import sys
 from subprocess import Popen, PIPE
 from genson import SchemaBuilder
 
@@ -25,7 +26,7 @@ def run(args=tuple(), stdin_data=None):
     Run the ``genson`` executable as a subprocess and return
     (stdout, stderr).
     """
-    full_args = ['python', '-m', 'genson']
+    full_args = [sys.executable, '-m', 'genson']
     full_args.extend(args)
     env = os.environ.copy()
     env['COLUMNS'] = '80'  # set width for deterministic text wrapping


### PR DESCRIPTION
Systems may not have a python executable in $PATH when running the testsuite. Since we're already running inside a Python process, we can leverage sys.executable to give us the full path instead.