### PR TITLE
fix: include genson.schema submodule in package build

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,9 +32,12 @@ classifiers =
     Topic :: Utilities
 
 [options]
-packages = genson
+packages = find:
 zip_safe = True
 include_package_data = True
+
+[options.packages.find]
+include = genson*
 
 [options.entry_points]
 console_scripts = genson = genson.__main__:main


### PR DESCRIPTION
The genson.schema submodule was not included when building and installing the package due to the package discovery configuration in setup.cfg.

Fixes #80