### PR TITLE
Add missing test files to the source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
 include *.rst
 include LICENSE
-recursive-include test *.json
+recursive-include test *.json *.py *.txt


### PR DESCRIPTION
Include all `*.py` and `*.txt` files in the source distribution. Currently, only `test_*.py` files are included and the other modules are missing.  There is also one `.txt` fixture that was missing.